### PR TITLE
Change X logo to 「𝕏」（U+1D54F）

### DIFF
--- a/index-en.html
+++ b/index-en.html
@@ -39,7 +39,7 @@
 [<a href="https://github.com/TeraTermProject/teraterm/releases">Download</a>] 
 [<a href="https://ci.appveyor.com/project/teraterm/github-main/history">Snapshot</a>] 
 [<a href="/manual/5/en/">Document</a>] 
-[<a href="https://x.com/Tera_Term">X</a>] 
+[<a href="https://x.com/Tera_Term">𝕏</a>] 
 [<a href="#Source">SourceCode</a>] 
 [<a href="#Development">Development</a>] 
 </p>

--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@
 [<a href="https://github.com/TeraTermProject/teraterm/releases">Download</a>]  
 [<a href="https://ci.appveyor.com/project/teraterm/github-main/history">Snapshot</a>] 
 [<a href="/manual/5/ja/">Document</a>] 
-[<a href="https://x.com/Tera_Term">X</a>] 
+[<a href="https://x.com/Tera_Term">𝕏</a>] 
 [<a href="#Source">SourceCode</a>] 
 [<a href="#Development">Development</a>] 
 </p>


### PR DESCRIPTION
旧 Twitterのロゴを「X」から「𝕏」（U+1D54F）にするプルリクエストです。